### PR TITLE
FIX: Template rendering bug

### DIFF
--- a/templates/Includes/SGSection.ss
+++ b/templates/Includes/SGSection.ss
@@ -37,10 +37,10 @@
 						<a title="Click to display the code." class="sg-example__toggle">Code</a>
 					</div>
 					<div class="sg-example">
-						$Template
+						$getTemplate
 					</div>
 					<div class="sg-code">
-				    	<pre class="prettyprint">$Template.XML</pre>
+				    	<pre class="prettyprint">$getTemplate.XML</pre>
 				    </div>
 				</div>
 		    </div>


### PR DESCRIPTION
With Silverstripe 3.3.1 in our environment $Template returns the Styleguide parameter and not the template (e.g it will print "Styleguide 2.0" for both the code and the preview). Changing the variable to $getTemplate fixes it, and the template is rendered correctly.
